### PR TITLE
catch standard error instead of error

### DIFF
--- a/lib/hypgen/worker/experiment_run.rb
+++ b/lib/hypgen/worker/experiment_run.rb
@@ -6,19 +6,23 @@ module Hypgen
       sidekiq_options queue: :experiment
       sidekiq_options :retry => false
 
-      def perform(exp_id, profile_ids, rabbitmq_location, start_time, end_time, deadline)
-        workflow = Workflow.new(exp_id, profile_ids, rabbitmq_location, start_time, end_time, deadline)
-        setup    = Planner.new(workflow).setup
-        set_id   = Hypgen.exp.start_as(setup, importance_level: 45)
+      def perform(exp_id, profile_ids, rabbitmq_location, start_time, end_time)
+        workflow = Workflow.new(exp_id, profile_ids,
+                                rabbitmq_location,
+                                start_time, end_time)
+        setup = Planner.new(workflow).setup
+        set_id = Hypgen.exp.start_as(setup, importance_level: 45)
 
         workflow.set_set_id(set_id)
         workflow.run!
-      rescue Exception => e
+      rescue StandardError => e
         #some debug output
         puts e.message
         puts e.backtrace
 
-        Hypgen.dap.update_exp(exp_id, { status: :error, status_message: e.message })
+        Hypgen.dap.update_exp(exp_id,
+                              status: :error,
+                              status_message: e.message)
       ensure
         Hypgen.exp.stop_as(set_id)
       end


### PR DESCRIPTION
[Here](http://stackoverflow.com/questions/10048173/why-is-it-bad-style-to-rescue-exception-e-in-ruby) is rationale why `Exception` should not be rescued

/cc @ismop/hypgen-dev-team please take a look